### PR TITLE
gen lst files for pgdb

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-nasm src/bootsectors/bmfs_mbr.asm -o bmfs_mbr.sys
-nasm src/bootsectors/pxestart.asm -o pxestart.sys
+nasm src/bootsectors/bmfs_mbr.asm -o bmfs_mbr.sys -l bmfs_mbr.lst
+nasm src/bootsectors/pxestart.asm -o pxestart.sys -l pxestart.lst
 cd src
-nasm pure64.asm -o ../pure64.sys
+nasm pure64.asm -o ../pure64.sys -l ../pure64.lst
 cd ..


### PR DESCRIPTION
I propose handling lst files the same way sys files are handled - build.sh in BareMetal can mv them all to a lst directory so they can all be handed to pgdb via a shell wildcard.
