### PR TITLE
Added Travis CI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+addons:
+  apt:
+    packages:
+    - nasm
+compiler:
+- gcc
+- clang
+script:
+- make pure64-0.7.1.tar.gz
+deploy:
+  provider: releases
+  api_key:
+    secure: Bb1dAXEAF6vumHAgc0BjXTDelgCiAqdSo0KjGvreuQyrH7W/5E5mnUlZdhHr9FpTDsBxm3KNtQytZmOI5Ge9dVn5f5ijggyGKLJgL96F7xvXeOcdjdTIv0HwyXePs3KsqVlqAayzCmRBtqgGhG3c4EouV21XIALb4sSLW6JGhdQ/jLvMxBV8kMxeReNA35NxOA0PIizFavAxoTvXBgpsuKp3MY1QMwkfsYPBQEoZCGlav2JnZmv5wpAXeVbsDz/xltFTC97billsOqag9bUxx7qMykFND1llmi8mlEVnz1FViaTam9MI89Od9ekKzRQ4OK1pnB3uPkOJDAuwvm4QKAsjqvNjb/yG2MdmDSLssaH0fgr/+jLZ6/BPo4rTA6+fX4KMZgrH76lqjijjmYoeHZT4IzmVn6hPgYIDGvla473tgGBBSpirWW5KON6YOF8CcdeF1pBQ09/pRFlv98yXe7pttgx2HtbMrr33dAs12Jep3au8zDFcbq/mtSXAwM22r6bkET8aQGGNJij2P8aWg5wppRnzEL8tXq7rq09nN7eFt/XE9hrM7f+bV7LGwzSsX4FcYWwgj07TAWHsK5oRxWU3gjsYl1qdjMT+NljA7DnbNv2co4v7bDCh/k8r97SYauNJL2ivG5NXbtfY7jSgML8F+4HxbxM/Dho9QB6xioM=
+  file: pure64-0.7.1.tar.gz
+  on:
+    repo: ReturnInfinity/Pure64

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION ?= 0.7.1
+
 .PHONY: all clean test install
 all clean test install:
 	$(MAKE) -C src $@
@@ -5,5 +7,11 @@ all clean test install:
 	$(MAKE) -C src/lib $@
 	$(MAKE) -C src/util $@
 	$(MAKE) -C include/pure64 $@
+
+pure64-$(VERSION).tar.gz: pure64-$(VERSION)
+	tar -pcvzf $@ $<
+
+pure64-$(VERSION):
+	$(MAKE) install DESTDIR=$(PWD)/$@ PREFIX=/
 
 $(V).SILENT:

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,24 @@
 # Pure64 -- an OS/software loader for x86-64 systems
-Copyright (C) 2008-2017 Return Infinity -- see LICENSE.TXT
 
-Pure64 is a software loader that was initially created for BareMetal OS. The loader sets the computer into a full 64-bit state with no legacy compatibility layers and also enables all available CPU Cores in the computer. Pure64 keeps an information table in memory that stores important details about the computer (Amount of RAM and memory layout, number of CPU cores and their APIC IDs, etc). The Pure64 loader has been released separately so others can use it in their own software projects.
+[![Build Status](https://travis-ci.org/ReturnInfinity/Pure64.svg?branch=master)](https://travis-ci.org/ReturnInfinity/Pure64)
+
+Copyright (C) 2008-2018 Return Infinity -- see LICENSE.TXT
+
+Pure64 is a software loader that was initially created for BareMetal OS.
+The loader sets the computer into a full 64-bit state with no legacy compatibility layers and also enables all available CPU Cores in the computer.
+Pure64 keeps an information table in memory that stores important details about the computer (Amount of RAM and memory layout, number of CPU cores and their APIC IDs, etc).
+The Pure64 loader has been released separately so others can use it in their own software projects.
 
 See LICENSE.TXT for redistribution/modification rights, and CREDITS.TXT for a list of people involved.
 
 Ian Seyler (ian.seyler@returninfinity.com)
 
-
 ## Building
 
-The only requirement for building Pure64 is [NASM](http://www.nasm.us/) (The Netwide Assembler). In Linux you can download it from your distributions repository(`apt-get install nasm`). If you are using Windows or macOS you can grab pre-compiled binaries [here](http://www.nasm.us/pub/nasm/releasebuilds/2.12.02/) in the `macosx` and `win32` directories, respectively.
+The only requirement for building Pure64 is [NASM](http://www.nasm.us/) (The Netwide Assembler) and GCC.
+In Linux you can download it from your distributions repository(`apt-get install nasm gcc`).
+If you are using Windows or macOS you can grab pre-compiled binaries [here](http://www.nasm.us/pub/nasm/releasebuilds/2.12.02/) in the `macosx` and `win32` directories, respectively.
+For GCC, you can use MinGW [here](https://sourceforge.net/projects/mingw/files/).
 
 Build scripts are included for macOS/Linux and Windows systems.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -54,6 +54,6 @@ clean:
 test:
 
 .PHONY: install
-install:
+install: $(targets)
 
 $(V).SILENT:

--- a/src/bootsectors/Makefile
+++ b/src/bootsectors/Makefile
@@ -17,6 +17,6 @@ clean:
 test:
 
 .PHONY: install
-install:
+install: $(targets)
 
 $(V).SILENT:


### PR DESCRIPTION
The top level Makefile now has a target you can use to build a compressed release file, called `pure64-0.7.1.tar.gz`. For example:

```
make pure64-0.7.1.tar.gz
```

The `readme.md` file not has a 'badge' containing the build status of the project. It should be pass, but we'll only know until a commit gets pushed to the main repo (for example, if this pull request gets merged).

I also updated the copyright year on the `readme.md` file, and added a note about installing GCC.