### PR TITLE
Added Logging, Increased Kernel Size Max, and Bumped Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pure64-0.7.1/
 /src/util/pure64-data.h
 /src/util/pure64-data.c
 /docs/html
+/docs/latex

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ compiler:
 - gcc
 - clang
 script:
-- make pure64-0.7.1.tar.gz
+- make pure64-0.9.0.tar.gz
 deploy:
   provider: releases
   api_key:
     secure: Bb1dAXEAF6vumHAgc0BjXTDelgCiAqdSo0KjGvreuQyrH7W/5E5mnUlZdhHr9FpTDsBxm3KNtQytZmOI5Ge9dVn5f5ijggyGKLJgL96F7xvXeOcdjdTIv0HwyXePs3KsqVlqAayzCmRBtqgGhG3c4EouV21XIALb4sSLW6JGhdQ/jLvMxBV8kMxeReNA35NxOA0PIizFavAxoTvXBgpsuKp3MY1QMwkfsYPBQEoZCGlav2JnZmv5wpAXeVbsDz/xltFTC97billsOqag9bUxx7qMykFND1llmi8mlEVnz1FViaTam9MI89Od9ekKzRQ4OK1pnB3uPkOJDAuwvm4QKAsjqvNjb/yG2MdmDSLssaH0fgr/+jLZ6/BPo4rTA6+fX4KMZgrH76lqjijjmYoeHZT4IzmVn6hPgYIDGvla473tgGBBSpirWW5KON6YOF8CcdeF1pBQ09/pRFlv98yXe7pttgx2HtbMrr33dAs12Jep3au8zDFcbq/mtSXAwM22r6bkET8aQGGNJij2P8aWg5wppRnzEL8tXq7rq09nN7eFt/XE9hrM7f+bV7LGwzSsX4FcYWwgj07TAWHsK5oRxWU3gjsYl1qdjMT+NljA7DnbNv2co4v7bDCh/k8r97SYauNJL2ivG5NXbtfY7jSgML8F+4HxbxM/Dho9QB6xioM=
-  file: pure64-0.7.1.tar.gz
+  file: pure64-0.9.0.tar.gz
   skip_cleanup: true
   on:
     repo: ReturnInfinity/Pure64

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Pure64"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "0.7.0"
+PROJECT_NUMBER         = "0.9.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -1666,7 +1666,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = NO
+GENERATE_LATEX         = YES
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.7.1
+VERSION ?= 0.9.0
 
 .PHONY: all clean test install
 all clean test install:

--- a/build.sh
+++ b/build.sh
@@ -11,8 +11,9 @@ nasm bootsectors/pxestart.asm  -o bootsectors/pxestart.sys
 
 # Build pure64.sys
 nasm pure64.asm -f elf64 -F dwarf -o pure64.o
-gcc -c load.c -o load.o -I ../include -fno-stack-protector
-ld pure64.o load.o -o pure64 -T pure64.ld
+gcc -c load.c -o load.o -I ../include -fno-stack-protector -mno-red-zone
+gcc -c debug.c -o debug.o -I ../include -fno-stack-protector -mno-red-zone
+ld pure64.o load.o debug.o -o pure64 -T pure64.ld
 objcopy -O binary pure64 pure64.sys
 
 # Build libpure64.a

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,14 +25,16 @@ pure64files += sysvar.asm
 .PHONY: all
 all: $(targets)
 
-pure64: pure64.o load.o pure64.ld
-	ld pure64.o load.o -T pure64.ld -o $@
+pure64: pure64.o debug.o load.o pure64.ld
+	ld pure64.o debug.o load.o -T pure64.ld -o $@
 
 # The dependencies of pure64.sys can
 # be (and should be) generated with
 # the command: nasm -M pure64.asm 1>pure64.mk
 # and used to update this target.
 pure64.o: $(pure64files)
+
+debug.o: debug.c debug.h
 
 load.o: load.c
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,35 @@
+/* =============================================================================
+ * Pure64 -- a 64-bit OS/software loader written in Assembly for x86-64 systems
+ * Copyright (C) 2008-2017 Return Infinity -- see LICENSE.TXT
+ * =============================================================================
+ */
+
+#include "debug.h"
+
+static void outb(unsigned short int port, unsigned char value) {
+	asm volatile ("outb %0, %1" : : "a"(value), "Nd"(port));
+}
+
+static unsigned char inb(unsigned short int port) {
+	unsigned char value;
+	asm volatile ("inb %1, %0" : "=a"(value) : "Nd"(port));
+	return value;
+}
+
+#define COM1 0x03f8
+
+void serial_putc(char c) {
+	for (;;) {
+		/* check if transmit is ready */
+		if (inb(COM1 + 5) & 0x20)
+			break;
+	}
+	outb(COM1, c);
+}
+
+void debug(const char *fmt, ...) {
+	while (*fmt) {
+		serial_putc(*fmt);
+		fmt++;
+	}
+}

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,20 @@
+/* =============================================================================
+ * Pure64 -- a 64-bit OS/software loader written in Assembly for x86-64 systems
+ * Copyright (C) 2008-2017 Return Infinity -- see LICENSE.TXT
+ * =============================================================================
+ */
+
+#ifndef PURE64_DEBUG_H
+#define PURE64_DEBUG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void debug(const char *fmt, ...);
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif
+
+#endif /* PURE64_DEBUG_H */

--- a/src/load.c
+++ b/src/load.c
@@ -205,6 +205,12 @@ static unsigned char *skip_dir(unsigned char *ptr) {
 	return ptr;
 }
 
+static void find_failure(const char *msg) {
+	debug("Failed to find kernel: \"");
+	debug(msg);
+	debug("\"\n");
+}
+
 static bool find_kernel(struct pure64_file *kernel) {
 
 	/* The kernel resides in '/boot/kernel'.
@@ -213,12 +219,26 @@ static bool find_kernel(struct pure64_file *kernel) {
 	 * */
 
 	/* beginning of the directories in '/' */
-	unsigned char *ptr = (unsigned char *) 0xa000 + 16;
+	unsigned char *ptr = (unsigned char *) 0xa000;
 
 	uint64_t i;
 	uint64_t file_count;
 	uint64_t dir_count;
 	uint64_t name_size;
+
+	if ((ptr[0] != 'P')
+	 || (ptr[1] != 'u')
+	 || (ptr[2] != 'r')
+	 || (ptr[3] != 'e')
+	 || (ptr[4] != '6')
+	 || (ptr[5] != '4')
+	 || (ptr[6] != 'F')
+	 || (ptr[7] != 'S')) {
+		find_failure("Pure64 file system not found.");
+		return false;
+	}
+
+	ptr += 16;
 
 	dir_count = *(uint64_t *)(&ptr[0x08]);
 
@@ -245,7 +265,7 @@ static bool find_kernel(struct pure64_file *kernel) {
 	}
 
 	if (i >= dir_count) {
-		/* TODO : error message: '/boot' not found. */
+		find_failure("The '/boot' directory was not found.");
 		return false;
 	}
 
@@ -291,7 +311,7 @@ static bool find_kernel(struct pure64_file *kernel) {
 		return true;
 	}
 
-	/* TODO : error message: 'kernel' not found in '/boot' */
+	find_failure("The '/boot/kernel' kernel file was not found.");
 
 	return false;
 }

--- a/src/load.c
+++ b/src/load.c
@@ -186,7 +186,7 @@ static bool find_kernel(struct pure64_file *kernel) {
 	 * */
 
 	/* beginning of the directories in '/' */
-	unsigned char *ptr = (unsigned char *) 0xa000;
+	unsigned char *ptr = (unsigned char *) 0xa000 + 16;
 
 	uint64_t i;
 	uint64_t file_count;

--- a/src/load.c
+++ b/src/load.c
@@ -7,6 +7,8 @@
 #include <pure64/dir.h>
 #include <pure64/file.h>
 
+#include "debug.h"
+
 typedef void (*kernel_entry)(void);
 
 static void pure64_memcpy(void *dst, const void *src, uint64_t size) {
@@ -28,12 +30,24 @@ void load(void) {
 
 	struct pure64_file kernel;
 
+	debug("Searching for kernel...\n");
+
 	if (!find_kernel(&kernel)) {
 		/* TODO :error message */
 		return;
 	}
 
+	debug("Kernel found.\n");
+
+	debug("Loading kernel...\n");
+
 	load_kernel(&kernel);
+}
+
+static void load_failure(const char *msg) {
+	debug("Failed to load kernel: \"");
+	debug(msg);
+	debug("\"\n");
 }
 
 static void load_kernel(struct pure64_file *kernel) {
@@ -55,22 +69,30 @@ static void load_kernel(struct pure64_file *kernel) {
 	 || (data[0x01] != 'E')
 	 || (data[0x02] != 'L')
 	 || (data[0x03] != 'F')) {
+		load_failure("Kernel is not in ELF format.");
 		return;
 	}
 
 	/* verify it is 64-bit */
-	if (data[0x04] != 2)
+	if (data[0x04] != 2) {
+		load_failure("Kernel is not 64-bit.");
 		return;
+	}
 
 	/* verify is little-endian */
-	if (data[0x05] != 1)
+	if (data[0x05] != 1) {
+		load_failure("Kernel is not little endian.");
 		return;
+	}
 
 	/* verify is executable */
 	if ((data[0x10] != 0x02)
-	 || (data[0x11] != 0x00))
+	 || (data[0x11] != 0x00)) {
+		load_failure("Kernel is not an executable.");
 		return;
+	}
 
+	/* TODO : what is this for? */
 	if ((data[0x12] != 0x3e)
 	 || (data[0x13] != 0x00))
 		return;
@@ -86,6 +108,7 @@ static void load_kernel(struct pure64_file *kernel) {
 	/* check to make sure the all the program
 	 * headers are available in memory */
 	if (data_size < (e_phoff + (e_phnum * e_phentsize))) {
+		load_failure("Kernel file is corrupt.");
 		return;
 	}
 
@@ -116,13 +139,17 @@ static void load_kernel(struct pure64_file *kernel) {
 		/* Verify the size of file is the same
 		 * or smaller than the required area in
 		 * memory */
-		if (p_filesz > p_memsz)
+		if (p_filesz > p_memsz) {
+			load_failure("Kernel file is corrupt.");
 			return;
+		}
 
 		/* Pure64 currently only supports
-		 * loading at this address. */
-		if (vaddr != ((void *) 0x400000))
+		 * loading at or above this address */
+		if (vaddr < ((void *) 0x100000)) {
+			load_failure("Invalid load address.");
 			return;
+		}
 
 		/* TODO : properly allocate memory,
 		 * checking to see if the address is

--- a/src/util/pure64.c
+++ b/src/util/pure64.c
@@ -210,7 +210,7 @@ static int ramfs_export(struct pure64_fs *fs, const char *filename) {
 	sector_count_buf[0] = (unsigned char)((sector_count >> 0x00) & 0xff);
 	sector_count_buf[1] = (unsigned char)((sector_count >> 0x08) & 0xff);
 
-	if (fwrite(sector_count_buf, 1, 2, file) != 4) {
+	if (fwrite(sector_count_buf, 1, 2, file) != 2) {
 		fprintf(stderr, "Failed to write sector count.\n");
 		return EXIT_FAILURE;
 	}

--- a/src/util/pure64.c
+++ b/src/util/pure64.c
@@ -192,32 +192,51 @@ static int ramfs_export(struct pure64_fs *fs, const char *filename) {
 		return EXIT_FAILURE;
 	}
 
-	/* update the number of sectors that the
-	 * boot loader should load. */
-
-	if (fseek(file, 0x01d2, SEEK_SET) != 0) {
-		fprintf(stderr, "Failed to seek to sector count offset.\n");
-		return EXIT_FAILURE;
+	if ((pos % 512) != 0) {
+		fseek(file, (pos + (512 - (pos % 512))) - 1, SEEK_SET);
+		fputc(0x00, file);
+		sector_count = ((pos - 0x2000) + 512) / 512;
 	}
 
-	sector_count = ((((uint64_t) pos) - 0x2000) + 512) / 512;
+	/* get ready to update the required
+	 * number of sectors to read from the
+	 * master boot record */
+
+	/* ensure that the sector
+	 * count can be contained
+	 * within a 16-bit, unsigned
+	 * integer.
+	 * */
 
 	if (sector_count > 0xffff) {
 		fprintf(stderr, "Pure64 file system is too large.\n");
 		return EXIT_FAILURE;
 	}
 
+	sector_count -= 1;
+
+	/* encode as little-endian */
+
 	sector_count_buf[0] = (unsigned char)((sector_count >> 0x00) & 0xff);
 	sector_count_buf[1] = (unsigned char)((sector_count >> 0x08) & 0xff);
+
+	/* go to the location in the
+	 * master boot record that contains
+	 * the sector count to read.
+	 */
+
+	if (fseek(file, 0x01d2, SEEK_SET) != 0) {
+		fprintf(stderr, "Failed to seek to sector count offset.\n");
+		return EXIT_FAILURE;
+	}
+
+	/* write the sector count to
+	 * the master boot record.
+	 */
 
 	if (fwrite(sector_count_buf, 1, 2, file) != 2) {
 		fprintf(stderr, "Failed to write sector count.\n");
 		return EXIT_FAILURE;
-	}
-
-	if (ftell(file) < (512 * 2048)) {
-		fseek(file, (512 * 2048) - 1, SEEK_SET);
-		fputc(0x00, file);
 	}
 
 	fclose(file);

--- a/src/util/pure64.c
+++ b/src/util/pure64.c
@@ -135,7 +135,7 @@ static int ramfs_export(struct pure64_fs *fs, const char *filename) {
 	FILE *file;
 	long int pos;
 	uint64_t sector_count;
-	unsigned char sector_count_buf[4];
+	unsigned char sector_count_buf[2];
 
 	struct pure64_stream stream;
 
@@ -202,12 +202,15 @@ static int ramfs_export(struct pure64_fs *fs, const char *filename) {
 
 	sector_count = ((((uint64_t) pos) - 0x2000) + 512) / 512;
 
+	if (sector_count > 0xffff) {
+		fprintf(stderr, "Pure64 file system is too large.\n");
+		return EXIT_FAILURE;
+	}
+
 	sector_count_buf[0] = (unsigned char)((sector_count >> 0x00) & 0xff);
 	sector_count_buf[1] = (unsigned char)((sector_count >> 0x08) & 0xff);
-	sector_count_buf[2] = (unsigned char)((sector_count >> 0x10) & 0xff);
-	sector_count_buf[3] = (unsigned char)((sector_count >> 0x18) & 0xff);
 
-	if (fwrite(sector_count_buf, 1, 4, file) != 4) {
+	if (fwrite(sector_count_buf, 1, 2, file) != 4) {
 		fprintf(stderr, "Failed to write sector count.\n");
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
In this pull request, several features were added.

The maximum size of the kernel was increased to 63.5KiB from 32KiB. Previously, 64 sectors are read from the master boot record. Now, the number of sectors that are read is the sum of the Pure64 binary and the file system, rounded up to the nearest sector. The kernel size is now limited by the BIOS extended read function, which is 127 sectors.

Logging has been added, via serial port COM1. There are now messages that are printed out when an error occurs. This may be the case if the kernel isn't found in the file system or if it is in the wrong format. There are several other corner cases that are handled as well.

Since the last release of Pure64 is 0.8.0, I bumped the version of the release to 0.9.0. However, I don't think a new release is appropriate right now. I would still like to add PE support again and UEFI support before 0.9.0 is officially released.