### PR TITLE
Removed Unused Function

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -e
 
 cd src/bootsectors && ./build.sh && cd ../..
 cd src && ./build.sh && cd ..
-cd src/lib && ./build.sh && cd ../..
+cd src/targetlib && ./build.sh && cd ../..
+cd src/hostlib && ./build.sh && cd ../..
 cd src/stage-three && ./build.sh && cd ../..
 cd src/util && ./build.sh && cd ../..

--- a/clean.sh
+++ b/clean.sh
@@ -2,6 +2,7 @@
 
 src/bootsectors/clean.sh
 src/clean.sh
-src/lib/clean.sh
+src/hostlib/clean.sh
+src/targetlib/clean.sh
 src/stage-three/clean.sh
 src/util/clean.sh

--- a/src/hostlib/build.sh
+++ b/src/hostlib/build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Set source files path
+srcdir=${PWD}/../lib/
+# Set compiler flags
+CFLAGS="$CFLAGS -O2"
+# Include the build script
+. ../lib/build.sh

--- a/src/hostlib/clean.sh
+++ b/src/hostlib/clean.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+rm -f *.o
+rm -f libpure64.a

--- a/src/lib/build.sh
+++ b/src/lib/build.sh
@@ -1,28 +1,28 @@
 #!/bin/sh
 
 # Enable all compiler warnings, treat warnings as errors
-CFLAGS="$CFLAGS-Wall -Wextra -Werror -Wfatal-errors"
+CFLAGS="$CFLAGS -Wall -Wextra -Werror -Wfatal-errors"
 # Enable C11 standard with GNU extensions
 CFLAGS="$CFLAGS -std=gnu11"
 # Pass flags required for use in kernel environment
-CFLAGS="$CFLAGS -fomit-frame-pointer -fno-stack-protector -mno-red-zone"
 # Pass the include directory
 CFLAGS="$CFLAGS -I ../../include"
 # Compiler is GNU
-CC=gcc
+CC=${CROSS_COMPILE}gcc
 # Build the object files
-$CC $CFLAGS -c dap.c
-$CC $CFLAGS -c dir.c
-$CC $CFLAGS -c error.c
-$CC $CFLAGS -c file.c
-$CC $CFLAGS -c fs.c
-$CC $CFLAGS -c gpt.c
-$CC $CFLAGS -c mbr.c
-$CC $CFLAGS -c misc.c
-$CC $CFLAGS -c path.c
-$CC $CFLAGS -c stream.c
-$CC $CFLAGS -c string.c
-$CC $CFLAGS -c uuid.c
+$CC $CFLAGS -c ${srcdir}dap.c
+$CC $CFLAGS -c ${srcdir}dir.c
+$CC $CFLAGS -c ${srcdir}error.c
+$CC $CFLAGS -c ${srcdir}file.c
+$CC $CFLAGS -c ${srcdir}fs.c
+$CC $CFLAGS -c ${srcdir}gpt.c
+$CC $CFLAGS -c ${srcdir}mbr.c
+$CC $CFLAGS -c ${srcdir}misc.c
+$CC $CFLAGS -c ${srcdir}partition.c
+$CC $CFLAGS -c ${srcdir}path.c
+$CC $CFLAGS -c ${srcdir}stream.c
+$CC $CFLAGS -c ${srcdir}string.c
+$CC $CFLAGS -c ${srcdir}uuid.c
 # Use ar from binutils
 AR=ar
 # Flags for creating library

--- a/src/lib/clean.sh
+++ b/src/lib/clean.sh
@@ -7,6 +7,7 @@ rm -f file.o
 rm -f fs.o
 rm -f mbr.o
 rm -f misc.o
+rm -f partition.o
 rm -f path.o
 rm -f stream.o
 rm -f string.o

--- a/src/stage-three/_start.c
+++ b/src/stage-three/_start.c
@@ -24,12 +24,6 @@
 #define NULL ((void *) 0x00)
 #endif
 
-void memset(void *a, void *b, unsigned long int size) {
-	(void) a;
-	(void) b;
-	(void) size;
-}
-
 typedef void (*kernel_entry)(void);
 
 static int find_file_system(struct pure64_map *map);

--- a/src/stage-three/build.sh
+++ b/src/stage-three/build.sh
@@ -7,24 +7,32 @@ CFLAGS="$CFLAGS-Wall -Wextra -Werror -Wfatal-errors"
 # Enable C11 standard with GNU extensions
 CFLAGS="$CFLAGS -std=gnu11"
 # Pass flags required for use in kernel environment
-CFLAGS="$CFLAGS -fomit-frame-pointer -fno-stack-protector -mno-red-zone"
+CFLAGS="$CFLAGS -ffreestanding"
 # Pass the include directory
 CFLAGS="$CFLAGS -I ../../include"
+# Set the cross compiler prefix
+CROSS_COMPILE=x86_64-none-elf-
+# Set the compiler name
+CC=${CROSS_COMPILE}gcc
 # Build the object files
-gcc $CFLAGS -c _start.c
-gcc $CFLAGS -c ahci.c
-gcc $CFLAGS -c debug.c
-gcc $CFLAGS -c e820.c
-gcc $CFLAGS -c hooks.c
-gcc $CFLAGS -c map.c
-gcc $CFLAGS -c pci.c
+$CC $CFLAGS -c _start.c
+$CC $CFLAGS -c ahci.c
+$CC $CFLAGS -c debug.c
+$CC $CFLAGS -c e820.c
+$CC $CFLAGS -c hooks.c
+$CC $CFLAGS -c map.c
+$CC $CFLAGS -c pci.c
+# Set the linker name
+LD=${CROSS_COMPILE}ld
 # Pass linker script
-LDFLAGS="$LDFLAGS -T stage-three.ld"
+LDFLAGS="$LDFLAGS -T stage-three.ld -nostdlib"
 # Pass library search directroy
-LDFLAGS="$LDFLAGS -L ../lib"
+LDFLAGS="$LDFLAGS -L ../targetlib"
 # Pass Pure64 library
 LDLIBS="$LDLIBS -lpure64"
 # Create the stage-three loader
-ld $LDFLAGS *.o -o stage-three $LDLIBS
+$LD $LDFLAGS *.o -o stage-three $LDLIBS
+# Set the objcopy name
+OBJCOPY=${CROSS_COMPILE}objcopy
 # Convert the loader into a flat binary
-objcopy -O binary stage-three stage-three.sys
+$OBJCOPY -O binary stage-three stage-three.sys

--- a/src/targetlib/build.sh
+++ b/src/targetlib/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Set the directory that the
+# source files can be found at.
+srcdir=${PWD}/../lib/
+# Set the cross compiler prefix
+CROSS_COMPILE=x86_64-none-elf-
+# Set the compiler flags
+CFLAGS="$CFLAGS -ffreestanding -Os"
+# Include the build source
+. ../lib/build.sh

--- a/src/targetlib/clean.sh
+++ b/src/targetlib/clean.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+rm -f *.o
+rm -f libpure64.a

--- a/src/util/build.sh
+++ b/src/util/build.sh
@@ -10,9 +10,15 @@ CFLAGS="$CFLAGS -I ../../include"
 gcc $CFLAGS rc.c -o rc
 # Generate the MBR source
 ./rc --input ../bootsectors/mbr.sys --source mbr-data.c --header mbr-data.h --name mbr_data
+# Generate the PXE source
+./rc --input ../bootsectors/pxestart.sys --source pxe-data.c --header pxe-data.h --name pxe_data
+# Generate the multiboot source
+./rc --input ../bootsectors/multiboot.sys --source multiboot-data.c --header multiboot-data.h --name multiboot_data
+# Generate the multiboot2 source
+./rc --input ../bootsectors/multiboot2.sys --source multiboot2-data.c --header multiboot2-data.h --name multiboot2_data
 # Generate the 2nd stage boot loader source
 ./rc --input ../pure64.sys --source pure64-data.c --header pure64-data.h --name pure64_data
 # Generate the 3rd stage boot loader source
 ./rc --input ../stage-three/stage-three.sys --source stage-three-data.c --header stage-three-data.h --name stage_three_data
 # Build the utility program
-gcc $CFLAGS pure64.c fstream.c mbr-data.c pure64-data.c stage-three-data.c -o pure64 ../lib/libpure64.a
+gcc $CFLAGS pure64.c fstream.c memory.c util.c config.c token.c mbr-data.c pxe-data.c multiboot-data.c multiboot2-data.c pure64-data.c stage-three-data.c -o pure64 ../hostlib/libpure64.a


### PR DESCRIPTION
This should fix the build error of having a builtin function that differs from the prototype. Removing this function should not break anything. I added it to get rid of an obscure clang error I was getting and then forgot to take it back out.