### PR TITLE
New verify method

### DIFF
--- a/src/arch/x86_64/bootsectors/mbr.asm
+++ b/src/arch/x86_64/bootsectors/mbr.asm
@@ -141,8 +141,8 @@ check_A20:
 	jc read_fail
 
 	; Verify that the 2nd stage boot loader was read.
-	mov eax, [0x8000]
-	cmp eax, 0x00017EE9		; Match against the Pure64 binary
+	mov ax, [0x8006]
+	cmp ax, 0x3436			; Match against the Pure64 binary
 	jne magic_fail
 
 	; Read the 3rd stage boot loader into memory.

--- a/src/arch/x86_64/bootsectors/pxestart.asm
+++ b/src/arch/x86_64/bootsectors/pxestart.asm
@@ -121,8 +121,8 @@ check_A20:
 	cmp ax, 0x004F			; Return value in AX should equal 0x004F if supported and successful
 	jne halt
 
-	mov eax, [0x8000]
-	cmp eax, 0x00017EE9		; Match against the Pure64 binary
+	mov ax, [0x8006]
+	cmp ax, 0x3436			; Match against the Pure64 binary
 	jne magic_fail
 
 ; At this point we are done with real mode and BIOS interrupts. Jump to 32-bit mode.

--- a/src/arch/x86_64/pure64.asm
+++ b/src/arch/x86_64/pure64.asm
@@ -27,8 +27,7 @@ STAGE3 equ 0x60000			; Stage three bootloader is at this address.
 start:
 	jmp start32			; This command will be overwritten with 'NOP's before the AP's are started
 	nop
-	nop
-	nop
+	db 0x36, 0x34
 
 ; =============================================================================
 ; Code for AP startup


### PR DESCRIPTION
Check for `64` at memory address 0x8006 instead of comparing the first 4 bytes where the `jmp` address may change.