### PR TITLE
Better BIOS/UEFI memory mapping

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -232,7 +232,17 @@ MPS INTI flags:
 <tr><td>Trigger Mode</td><td>2</td><td>2</td><td>01 Edge-triggered, 11 Level-triggered</td></tr>
 </table>
 
-A copy of the UEFI System Memory Map is stored at memory address `0x0000000000006000`. Each UEFI record is 48 bytes in length and the memory map is terminated by a blank record.
+A copy of the BIOS System Memory Map is stored at memory address `0x0000000000006000`. Each BIOS record is 32 bytes in length and the memory map is terminated by a blank record.
+<table border="1" cellpadding="2" cellspacing="0">
+<tr><th>Variable</th><th>Variable Size</th><th>Description</th></tr>
+<tr><td>Base</td><td>64-bit</td><td>Base Address</td></tr>
+<tr><td>Length</td><td>64-bit</td><td>Length in bytes</td></tr>
+<tr><td>Type</td><td>32-bit</td><td>Type of memory (1 is usable)</td></tr>
+<tr><td>ACPI</td><td>32-bit</td><td>See document linked below</td></tr>
+</table>
+For more information on the BIOS Memory Map: <a href="https://wiki.osdev.org/Detecting_Memory_(x86)#BIOS_Function:_INT_0x15,_EAX_=_0xE820">BIOS Specs</a>
+
+A copy of the UEFI System Memory Map is stored at memory address `0x0000000000200000`. Each UEFI record is 48 bytes in length and the memory map is terminated by a blank record.
 <table border="1" cellpadding="2" cellspacing="0">
 <tr><th>Variable</th><th>Variable Size</th><th>Description</th></tr>
 <tr><td>Type</td><td>64-bit</td><td>The type of the memory region</td></tr>

--- a/docs/README.md
+++ b/docs/README.md
@@ -242,7 +242,7 @@ A copy of the BIOS System Memory Map is stored at memory address `0x000000000000
 </table>
 For more information on the BIOS Memory Map: <a href="https://wiki.osdev.org/Detecting_Memory_(x86)#BIOS_Function:_INT_0x15,_EAX_=_0xE820">BIOS Specs</a>
 
-A copy of the UEFI System Memory Map is stored at memory address `0x0000000000200000`. Each UEFI record is 48 bytes in length and the memory map is terminated by a blank record.
+A copy of the UEFI System Memory Map is stored at memory address `0x0000000000220000`. Each UEFI record is 48 bytes in length and the memory map is terminated by a blank record.
 <table border="1" cellpadding="2" cellspacing="0">
 <tr><th>Variable</th><th>Variable Size</th><th>Description</th></tr>
 <tr><td>Type</td><td>64-bit</td><td>The type of the memory region</td></tr>

--- a/src/boot/uefi.asm
+++ b/src/boot/uefi.asm
@@ -421,7 +421,7 @@ FBS:			dq 0					; Frame buffer size
 HR:			dq 0					; Horizontal Resolution
 VR:			dq 0					; Vertical Resolution
 PPSL:			dq 0					; PixelsPerScanLine
-memmap:			dq 0x200000				; Store the Memory Map from UEFI here
+memmap:			dq 0x220000				; Store the Memory Map from UEFI here
 memmapsize:		dq 32768				; Max size we are expecting in bytes
 memmapkey:		dq 0
 memmapdescsize:		dq 0

--- a/src/pure64.asm
+++ b/src/pure64.asm
@@ -434,7 +434,6 @@ bios_memmap_nextentry:
 	je bios_memmap_processfree
 	add esi, 16			; Skip ESI to start of next entry
 	jmp bios_memmap_nextentry
-
 bios_memmap_processfree:
 	; TODO Check ACPI 3.0 Extended Attributes - Bit 0 should be set
 	sub esi, 16
@@ -450,7 +449,6 @@ bios_memmap_processfree:
 	stosq
 	add ebx, ecx
 	jmp bios_memmap_nextentry
-
 bios_memmap_end820:
 
 memmap_end:
@@ -459,10 +457,6 @@ memmap_end:
 	xor eax, eax
 	stosq
 	stosq
-
-; UEFI HACKIN'
-;	cmp byte [p_BootMode], 'U'
-;	je hack
 
 ; Create the High Page-Directory-Pointer-Table Entries (PDPTE)
 ; High PDPTE is stored at 0x0000000000004000, create the first entry there
@@ -509,36 +503,6 @@ pde_high:				; Create a 2MiB page
 	jne pde_high
 	jmp pde_next_range
 pde_end:
-	jmp idt
-
-; UEFI HACKIN' START
-
-hack:
-	mov rcx, 1			; number of PDPE's to make.. each PDPE maps 1GB of physical memory
-	mov edi, 0x00004000		; location of high PDPE
-	mov eax, 0x00020007		; location of first high PD. Bits (0) P, 1 (R/W), and 2 (U/S) set
-hack_create_pdpe_high:
-	stosq
-	add rax, 0x00001000		; 4K later (512 records x 8 bytes)
-	dec ecx
-	cmp ecx, 0
-	jne hack_create_pdpe_high
-
-	mov edi, 0x00020000		; Location of first PDE
-	mov eax, 0x0000008F		; Bits 0 (P), 1 (R/W), 2 (U/S), 3 (PWT), and 7 (PS) set
-	add rax, 0x00400000		; Start at 4MiB in (0-2MiB for system, 2MiB-4MiB for stacks)
-	mov ecx, 64
-	shr ecx, 1
-hack_pde_high:				; Create a 2MiB page
-	stosq
-	add rax, 0x00200000		; Increment by 2MiB
-	dec ecx
-	cmp ecx, 0
-	jne hack_pde_high
-
-; UEFI HACKIN' END
-
-idt:
 
 ; Build the IDT
 	xor edi, edi 			; create the 64-bit IDT (at linear address 0x0000000000000000)


### PR DESCRIPTION
This maps all available memory above the first 4MiB to `0xFFFF800000000000`.