### PR TITLE
Add flag for NASM v3+

### DIFF
--- a/src/boot/uefi.asm
+++ b/src/boot/uefi.asm
@@ -14,6 +14,7 @@
 
 BITS 64
 ORG 0x00400000
+DEFAULT ABS
 %define u(x) __utf16__(x)
 
 START:

--- a/src/pure64.asm
+++ b/src/pure64.asm
@@ -19,6 +19,7 @@
 
 BITS 64
 ORG 0x00008000
+DEFAULT ABS
 PURE64SIZE equ 6144			; Pad Pure64 to this length
 
 start:


### PR DESCRIPTION
This pull request introduces a minor update to the assembly bootloader source files by specifying the default addressing mode as absolute. This change helps clarify the intended addressing mode for the assembler and can prevent potential ambiguities or errors in code interpretation.

Assembly configuration improvements:

* Added `DEFAULT ABS` directive at the top of both `src/boot/uefi.asm` and `src/pure64.asm` to explicitly set the default addressing mode to absolute. [[1]](diffhunk://#diff-333f357cb4d96dc8c73112211e418774e82abe9b9df31878637dfac12077b579R17) [[2]](diffhunk://#diff-1bf861896df7b0e7f25974ad0fb54e614f2554261c3b2335a27f4b87bba82863R22)